### PR TITLE
release: Update to 0.2.0 - markitdown and content processors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,8 +317,8 @@ genai-processors-url-fetch/
 
 Releases are automated via GitHub Actions:
 
-1. **Create a tag**: `git tag v0.1.0`
-2. **Push tag**: `git push origin v0.1.0`
+1. **Create a tag**: `git tag 0.1.0`
+2. **Push tag**: `git push origin 0.1.0`
 3. **GitHub Actions** automatically:
    - Builds the package
    - Runs full test suite

--- a/genai_processors_url_fetch/__init__.py
+++ b/genai_processors_url_fetch/__init__.py
@@ -10,5 +10,5 @@ This is an independent contrib processor for the genai-processors ecosystem.
 
 from .url_fetch import FetchConfig, UrlFetchProcessor
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["UrlFetchProcessor", "FetchConfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-processors-url-fetch"
-version = "0.1.0"
+version = "0.2.0"
 description = "A URL fetch processor for Google's genai-processors framework"
 authors = [
     {name = "Mark Beacom", email = "m@beacom.dev"},

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ wheels = [
 
 [[package]]
 name = "genai-processors-url-fetch"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
This pull request updates the version of the `genai-processors-url-fetch` package to `0.2.0` and makes minor adjustments to the release process documentation. Below are the key changes:

### Version Update:
* Updated the version in `pyproject.toml` from `0.1.0` to `0.2.0` to reflect the new release.
* Updated the `__version__` attribute in `genai_processors_url_fetch/__init__.py` to match the new version `0.2.0`.

### Documentation Adjustment:
* Modified the release instructions in `CONTRIBUTING.md` to remove the leading "v" from the tag creation and push commands for consistency.