### PR TITLE
chore: Bump version to 0.3.2 in __init__.py, pyproject.toml, and uv.lock

### DIFF
--- a/genai_processors_url_fetch/__init__.py
+++ b/genai_processors_url_fetch/__init__.py
@@ -10,5 +10,5 @@ This is an independent contrib processor for the genai-processors ecosystem.
 
 from .url_fetch import ContentProcessor, FetchConfig, UrlFetchProcessor
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __all__ = ["UrlFetchProcessor", "FetchConfig", "ContentProcessor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-processors-url-fetch"
-version = "0.3.1"
+version = "0.3.2"
 description = "A URL fetch processor for Google's genai-processors framework"
 authors = [
     {name = "Mark Beacom", email = "m@beacom.dev"},

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "genai-processors-url-fetch"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
This pull request updates the package version from 0.3.1 to 0.3.2 to reflect a new release. No other changes are included.

* Bumped the version in both `genai_processors_url_fetch/__init__.py` and `pyproject.toml` from 0.3.1 to 0.3.2. [[1]](diffhunk://#diff-5ef7138050ab0ae7118724181ae98b61529ac89cd2ebaa0ec4fc9d91742e63edL13-R13) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)